### PR TITLE
added ability to add multiple links with the same name

### DIFF
--- a/src/main/scala/haldr/Resource.scala
+++ b/src/main/scala/haldr/Resource.scala
@@ -37,6 +37,10 @@ class Resource private[haldr] (
     link(rel, lnk)
   }
 
+  def link[T <: LinkObject](rel: String, lnks: T*): Resource = {
+    lnks.foldLeft(this)((t, lnk) => t.link(rel, lnk))
+  }
+
   def embed(rel: String, x: Resource): Resource = {
     embeds += (rel -> Left(Left(x)))
     this

--- a/src/test/scala/haldr/HaldrSpec.scala
+++ b/src/test/scala/haldr/HaldrSpec.scala
@@ -236,6 +236,31 @@ class HaldrSpec extends Specification {
         """.parseJson
       }
 
+      "multiple links with same name" >> {
+        val customer =
+          Resource(
+            Customer("test@gmail.com"), u"/customers/deadbeaf")
+            .link("books", r"/books/1")
+            .link("books", r"/books/2")
+            .link("books", r"/books/3", r"/books/4")
+
+        customer.toJson must_==
+          """
+        {
+           "email": "test@gmail.com",
+           "_links": {
+              "self": {"href": "/customers/deadbeaf"},
+              "books": [
+                {"href": "/customers/deadbeaf/books/1"},
+                {"href": "/customers/deadbeaf/books/2"},
+                {"href": "/customers/deadbeaf/books/3"},
+                {"href": "/customers/deadbeaf/books/4"}
+              ]
+            }
+        }
+          """.parseJson
+      }
+
       "relative DRY links" >> {
         val customer =
           Resource(


### PR DESCRIPTION
Hi, 

I have added the ability to link multiple resources with the same link as can be seen at http://blog.stateless.co/post/13296666138/json-linking-with-hal (second example).

P.S. I couldn't find 0.3 release on any repository(http://mvnrepository.com/artifact/com.github.ancane shows only 0.2 and 0.1)
